### PR TITLE
Fix OAuth edge case

### DIFF
--- a/Application/Sources/Network/APIClient (Authentication).swift
+++ b/Application/Sources/Network/APIClient (Authentication).swift
@@ -26,8 +26,8 @@ extension APIClient {
 		OAuth2Grant.grant.password = password
 
 		OAuth2Grant.grant.authorize { (_: OAuth2JSON?, error: OAuth2Error?) in
-            OAuth2Grant.grant.username = nil
-            OAuth2Grant.grant.password = nil
+			OAuth2Grant.grant.username = nil
+			OAuth2Grant.grant.password = nil
 			handler(error)
 		}
 	}

--- a/Application/Sources/Network/APIClient (Authentication).swift
+++ b/Application/Sources/Network/APIClient (Authentication).swift
@@ -26,6 +26,8 @@ extension APIClient {
 		OAuth2Grant.grant.password = password
 
 		OAuth2Grant.grant.authorize { (_: OAuth2JSON?, error: OAuth2Error?) in
+            OAuth2Grant.grant.username = nil
+            OAuth2Grant.grant.password = nil
 			handler(error)
 		}
 	}


### PR DESCRIPTION
This fixes an issue where you would not logout when the OAuthGrant still has credentials in memory and access/refresh tokens were revoked by the server.