### PR TITLE
Fix race condition for client session

### DIFF
--- a/Application/Sources/Network/APIClient.swift
+++ b/Application/Sources/Network/APIClient.swift
@@ -14,9 +14,15 @@ final class APIClient: Client {
 	static let shared = APIClient()
 
 	private let interceptor = AuthenticationInterceptor(authenticator: OAuth2Authenticator(), credential: OAuth2Grant.grant)
-	private(set) lazy var session = Session(interceptor: interceptor)
-	private(set) lazy var nuke = Nuke.ImagePipeline {
-		$0.dataLoader = NukeAlamofirePlugin.AlamofireDataLoader(session: self.session)
+
+	let session: Session
+	let nuke: ImagePipeline
+
+	init() {
+		let newSession = Session(interceptor: interceptor)
+
+		session = newSession
+		nuke = .init { $0.dataLoader = AlamofireDataLoader(session: newSession) }
 	}
 
 	func nukeOptions(placeholder: PlatformImage? = nil, transition: ImageLoadingOptions.Transition? = nil, failureImage: PlatformImage? = nil, failureImageTransition: ImageLoadingOptions.Transition? = nil, contentModes: ImageLoadingOptions.ContentModes? = nil) -> ImageLoadingOptions {


### PR DESCRIPTION
This fixes a race condition that occurs when the session object is accessed from multiple threads during session initialization causing the network request to fail due too the session being deinitialized. 
Changing the session creation to the `init` makes this thread safe for singletons. 
